### PR TITLE
bugfix: in mode WX_FIXED - write wxTcall on display

### DIFF
--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -585,9 +585,9 @@ void loop() {
       }
     } else {                              // ab hier WX_FIXED code
       if (hum_temp) {
-        writedisplaytext(" "+Tcall,"Time to TX: "+String(((lastTX+nextTX)-millis())/1000)+"sec","LAT: "+LatShown,"LON: "+LongShown,"SPD: ---  CRS: ---","BAT: "+String(BattVolts,1)+"  HUM: "+String(hum,1),0);
+        writedisplaytext(" "+wxTcall,"Time to TX: "+String(((lastTX+nextTX)-millis())/1000)+"sec","LAT: "+LatShown,"LON: "+LongShown,"SPD: ---  CRS: ---","BAT: "+String(BattVolts,1)+"  HUM: "+String(hum,1),0);
       } else {
-        writedisplaytext(" "+Tcall,"Time to TX: "+String(((lastTX+nextTX)-millis())/1000)+"sec","LAT: "+LatShown,"LON: "+LongShown,"SPD: ---  CRS: ---","SAT: ---  TEMP: "+String(temp,1),0);
+        writedisplaytext(" "+wxTcall,"Time to TX: "+String(((lastTX+nextTX)-millis())/1000)+"sec","LAT: "+LatShown,"LON: "+LongShown,"SPD: ---  CRS: ---","SAT: ---  TEMP: "+String(temp,1),0);
       }
     }
   }


### PR DESCRIPTION
When using Mode: WX_FIXED - it creates APRS messages with the "wxTcall" - but in display was Tcall