### PR TITLE
sometimes Adafruit BusIO is missing

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ board = ttgo-t-beam
 framework = arduino
 monitor_speed = 115200
 lib_deps = 
+	Adafruit BusIO
 	RadioHead
 	TinyGPSPlus
 	DHT sensor library for ESPx


### PR DESCRIPTION
in some cases the Adafruit BusIO is missing, so the compiling is failing.