### PR TITLE
BME280 added measurement of air pressure

### DIFF
--- a/src/TTGO_T-Beam_LoRa_APRS_config.h
+++ b/src/TTGO_T-Beam_LoRa_APRS_config.h
@@ -36,6 +36,7 @@
 // SET temperature sensor type
 // #define DS18B20    // use this if you use DS18B20, default is DHT22
 // #define USE_BME280 // use this if you use BME280,m default is DHT22
+// #define HEIGTH_PRESET 234    // if you use BME280, the heigth of your location above mean sea level in meters
 
 // USER DATA - USE THESE LINES TO MODIFY YOUR PREFERENCES
 // IF NOT CHANGED you have to go through the configuration routine at first boot up of the TTGO T-Beam


### PR DESCRIPTION
Hi,

I've seen, that for BME280 sensors only temperature and humidity are measured and sent in the APRS messages.

My push request adds the measurement and transmission of the air pressure via APRS messages.
Because air pressure has to be given for a defined height at sea level there has to be calculated an offset to the measured pressure which depends on the height of the tracker. If the tracker is in a mode where GPS is active, the height is used from GPS. In WX_FIXED mode (without GPS) the height is used as fixed heigth from HEIGTH_PRESET in TTGO_T-Beam_LoRa_APRS_config.h.

I've implemented a very simple function calc_pressure_offset() into TTGO_T-Beam_LoRa_APRS.ino to calculate this offset. Maybe, this gives results, which are not exact enough. Then we should use some more complicated calculations there.

73s de Thomas, DG0OFZ