### PR TITLE
Battery Voltage in APRS 'Comment':  mode WX_FIXED

### DIFF
--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -921,6 +921,12 @@ switch(tracker_mode) {
       outString += "b.....";
     #endif
     outString += MY_COMMENT;
+    #ifdef HW_COMMENT
+      outString += (" --");
+      outString += " Batt=";
+      outString += String(BattVolts,2);
+      outString += ("V");
+    #endif
     break;
   case WX_TRACKER:
     if (wx) {


### PR DESCRIPTION
Appended battery voltage to end of APRS 'Comment' if HW_COMMENT is UNcommented for operation mode WX_FIXED