### PR TITLE
Remove bug when humidity = 100%

### DIFF
--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -908,9 +908,14 @@ switch(tracker_mode) {
     outString += helper;
     outString += "r...p...P...h";
     if(hum<10) {outString += "0"; }
-    helper = String(hum,0);
-    helper.trim();
-    outString += helper;
+    if(hum<100) {
+      helper = String(hum,0);
+      helper.trim();
+      outString += helper;
+    } else {
+      // if humidity = 100% then send it as "00" as defined in APRS spec
+      outString += "00";
+    }
     #ifdef USE_BME280
       outString += "b";
       if(pressure<1000) {outString += "0"; }
@@ -999,9 +1004,14 @@ switch(tracker_mode) {
       outString += helper;
       outString += "r...p...P...h";
       if(hum<10) {outString += "0"; }
-      helper = String(hum,0);
-      helper.trim();
-      outString += helper;
+      if(hum<100) {
+        helper = String(hum,0);
+        helper.trim();
+        outString += helper;
+      } else {
+        // if humidity = 100% then send it as "00" as defined in APRS spec
+        outString += "00";
+      }
       #ifdef USE_BME280
         outString += "b";
         if(pressure<1000) {outString += "0"; }
@@ -1149,9 +1159,14 @@ case WX_MOVE:
     outString += helper;
     outString += "r...p...P...h";
     if(hum<10) {outString += "0"; }
-    helper = String(hum,0);
-    helper.trim();
-    outString += helper;
+    if(hum<100) {
+      helper = String(hum,0);
+      helper.trim();
+      outString += helper;
+    } else {
+      // if humidity = 100% then send it as "00" as defined in APRS spec
+      outString += "00";
+    }
     #ifdef USE_BME280
       outString += "b";
       if(pressure<1000) {outString += "0"; }


### PR DESCRIPTION
Humidity was sent as 'h100' when it is 100%. 
But this ist not conform to the APRS spec, which states it has to be with an "h" followed by 2 digits and 00 = 100%.

Now it is conform to the spec.